### PR TITLE
강의 후기, 시간표 기능 개선

### DIFF
--- a/src/main/java/in/hangang/controller/LectureController.java
+++ b/src/main/java/in/hangang/controller/LectureController.java
@@ -49,8 +49,8 @@ public class LectureController {
     @Auth
     @ApiOperation(value = "강의 스크랩 삭제", notes = "스크랩했던 강의를 삭제합니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/scrap/lecture", method = RequestMethod.DELETE)
-    public ResponseEntity deleteScrapLecture(@RequestBody Lecture lecture) throws Exception{
-        lectureService.deleteScrapLecture(lecture);
+    public ResponseEntity deleteScrapLecture(@RequestBody ArrayList<Long> id) throws Exception{
+        lectureService.deleteScrapLecture(id);
         return new ResponseEntity( new BaseResponse("스크랩을 정상적으로 삭제했습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 

--- a/src/main/java/in/hangang/controller/ReviewController.java
+++ b/src/main/java/in/hangang/controller/ReviewController.java
@@ -6,6 +6,7 @@ import in.hangang.domain.Lecture;
 import in.hangang.domain.Report;
 import in.hangang.domain.criteria.Criteria;
 import in.hangang.domain.Review;
+import in.hangang.enums.Board;
 import in.hangang.enums.ContentType;
 import in.hangang.response.BaseResponse;
 import in.hangang.service.ReportService;
@@ -32,14 +33,15 @@ public class ReviewController {
     @Resource
     ReportService reportService;
 
-    // 전체 후기 리스트
+    // CRUD ------------------------------------------------------------------------------------------------------
+    // 강의 후기 전체 READ
     @ApiOperation( value = "모든 강의 후기 읽기", notes = "등록된 모든 강의 후기를 읽어옵니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews", method = RequestMethod.GET)
     public ResponseEntity getReviewList(@ModelAttribute Criteria criteria) throws Exception {
         return new ResponseEntity<ArrayList<Review>>(reviewService.getReviewList(criteria), HttpStatus.OK);
     }
 
-    // 후기 Read
+    // 강의 후기 개별 READ
     @Auth
     @ApiOperation( value = "강의 후기 읽기", notes = "하나의 강의 후기를 확인할 수 있습니다. 강의 후기 ID를 파라미터로 주면 됩니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews/{id}", method = RequestMethod.GET)
@@ -47,7 +49,7 @@ public class ReviewController {
         return new ResponseEntity<Review>(reviewService.getReview(id), HttpStatus.OK);
     }
 
-    // 해당 강의에 등록된 후기 Read
+    // 강의별 후기 READ
     @Auth
     @ApiOperation( value = "강의에 등록된 후기 읽기", notes = "해당 강의에 등록된 모든 후기를 확인할 수 있습니다.\n강의 ID를 파라미터로 주면 됩니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews/lectures/{id}", method = RequestMethod.GET)
@@ -55,7 +57,15 @@ public class ReviewController {
         return new ResponseEntity<ArrayList<Review>>(reviewService.getReviewByLectureId(id, criteria), HttpStatus.OK);
     }
 
-    // 후기 Create
+    // 강의별 후기 READ : 시간표에 등록된 강의의 강의 후기를 읽을 때 사용
+    @Auth
+    @ApiOperation( value = "강의에 등록된 후기 읽기", notes = "해당 강의에 등록된 모든 후기를 확인할 수 있습니다.\n강의 ID를 파라미터로 주면 됩니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
+    @RequestMapping(value = "/reviews/timetable/lecture", method = RequestMethod.GET)
+    public ResponseEntity<Lecture> getReviewByTimeTableLecture(Long lectureId) throws Exception{
+        return new ResponseEntity<Lecture>(reviewService.getReviewByTimeTableLecture(lectureId), HttpStatus.OK);
+    }
+
+    // 후기 CREATE
     @Auth
     @ApiOperation( value = "강의 후기 작성", notes = "강의 후기 작성 성기능입니다." +
             "\nassignment : 과제 정보 ID\nassignment_amount : 과제량 (3:상, 2:중, 1:하)\nattendance_frequency : 출첵 빈도 (3:상, 2:중, 1:하)\ncomment : 강의 후기 (10글자 이상)" +
@@ -67,7 +77,8 @@ public class ReviewController {
         return new ResponseEntity(HttpStatus.OK);
     }
 
-    // 후기 추천수 기능
+    // 추천 기능 ------------------------------------------------------------------------------------------------------
+    // 추천 CREATE
     @Auth
     @ApiOperation( value = "강의 후기 추천", notes = "강의 후기 추천 기능입니다. 파라미터로 reviewID를 주면 됩니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/review/recommend", method = RequestMethod.POST)
@@ -76,7 +87,8 @@ public class ReviewController {
         return new ResponseEntity(new BaseResponse("정상적으로 추천되었습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 
-    // 리뷰 신고
+    // 신고 기능 ------------------------------------------------------------------------------------------------------
+    // 리뷰 신고 CREATE
     @Auth
     @RequestMapping(value = "/review/report", method = RequestMethod.POST)
     @ApiOperation(value ="강의자료 신고" , notes = "파라미터는 강의 자료 id 입니다\n REPORT 내용 별 id =>"
@@ -84,10 +96,12 @@ public class ReviewController {
             "    4: \"광고/도배\", 5: \"음란물\""
             ,authorizations = @Authorization(value = "Bearer +accessToken"))
     public ResponseEntity reportLectureBank(@RequestBody Report report) throws Exception {
-        reportService.createReport(ContentType.REVIEW.getTypeId(), report);
-        return new ResponseEntity(HttpStatus.OK);
+        reportService.createReport(Board.REVIEW.getId(), report);
+        return new ResponseEntity(new BaseResponse("정상적으로 신고되었습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 
+    // 스크랩 기능 ------------------------------------------------------------------------------------------------------
+    // 스크랩 READ
     @Auth
     @ApiOperation( value = "자신이 스크랩한 리뷰 조회", notes = "해당 유저가 스크랩한 모든 리뷰를 조회할 수 있습니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews/scrap", method = RequestMethod.GET)
@@ -95,6 +109,7 @@ public class ReviewController {
         return new ResponseEntity<ArrayList<Review>>(reviewService.getScrapReviewList(), HttpStatus.OK);
     }
 
+    // 스크랩 CREATE
     @Auth
     @ApiOperation( value = "강의 리뷰 스크랩", notes = "강의 리뷰를 스크랩합니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews/scrap", method = RequestMethod.POST)
@@ -103,6 +118,7 @@ public class ReviewController {
         return new ResponseEntity( new BaseResponse("리뷰가 정상적으로 추가되었습니다", HttpStatus.OK), HttpStatus.OK);
     }
 
+    // 스크랩 DELETE
     @Auth
     @ApiOperation( value = "스크랩 삭제", notes = "스크랩한 리뷰를 삭제합니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/reviews/scrap", method = RequestMethod.DELETE)
@@ -118,10 +134,6 @@ public class ReviewController {
         return new ResponseEntity(reviewService.getCountScrapReview(), HttpStatus.OK);
     }
 
-    @Auth
-    @ApiOperation( value = "강의에 등록된 후기 읽기", notes = "해당 강의에 등록된 모든 후기를 확인할 수 있습니다.\n강의 ID를 파라미터로 주면 됩니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
-    @RequestMapping(value = "/reviews/timetable/lecture", method = RequestMethod.GET)
-    public ResponseEntity<Lecture> getReviewByTimeTableLecture(Long lectureId) throws Exception{
-        return new ResponseEntity<Lecture>(reviewService.getReviewByTimeTableLecture(lectureId), HttpStatus.OK);
-    }
+
+
 }

--- a/src/main/java/in/hangang/controller/TimeTableController.java
+++ b/src/main/java/in/hangang/controller/TimeTableController.java
@@ -58,8 +58,8 @@ public class TimeTableController {
     @Auth
     @ApiOperation( value = "시간표 삭제", notes = "자신의 시간표를 삭제할 수 있습니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/timetable", method = RequestMethod.DELETE)
-    public ResponseEntity deleteTimeTable(@RequestBody TimeTable timeTable) throws Exception{
-        timetableService.deleteTimetable(timeTable);
+    public ResponseEntity deleteTimeTable(@RequestBody UserTimeTable userTimeTable) throws Exception{
+        timetableService.deleteTimetable(userTimeTable);
         return new ResponseEntity( new BaseResponse("시간표가 삭제되었습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 
@@ -88,8 +88,8 @@ public class TimeTableController {
     @Auth
     @ApiOperation( value = "메인 시간표 변경", notes = "메인 시간표를 변경할 수 있습니다.", authorizations = @Authorization(value = "Bearer +accessToken"))
     @RequestMapping(value = "/timetable/main/lecture", method = RequestMethod.PATCH)
-    public ResponseEntity updateMainTimeTable(@RequestBody TimeTable timeTable) throws Exception{
-        timetableService.updateMainTimeTable(timeTable);
+    public ResponseEntity updateMainTimeTable(@RequestBody UserTimeTable userTimeTable) throws Exception{
+        timetableService.updateMainTimeTable(userTimeTable);
         return new ResponseEntity( new BaseResponse("메인 시간표가 변경되었습니다.", HttpStatus.OK), HttpStatus.OK);
     }
 

--- a/src/main/java/in/hangang/domain/Report.java
+++ b/src/main/java/in/hangang/domain/Report.java
@@ -8,7 +8,7 @@ public class Report {
     @ApiModelProperty(hidden = true)
     private Long id;
     @ApiModelProperty(hidden = true)
-    Integer type_id;
+    Integer board_type_id;
     @NotNull(message = "신고할 컨텐츠의 id는 비워둘 수 없습니다.")
     Long content_id;
     @NotNull(message = "신고 내용은 비워둘 수 없습니다.")
@@ -24,12 +24,12 @@ public class Report {
         this.id = id;
     }
 
-    public Integer getType_id() {
-        return type_id;
+    public Integer getBoard_type_id() {
+        return board_type_id;
     }
 
-    public void setType_id(Integer type_id) {
-        this.type_id = type_id;
+    public void setBoard_type_id(Integer board_type_id) {
+        this.board_type_id = board_type_id;
     }
 
     public Long getContent_id() {

--- a/src/main/java/in/hangang/enums/Board.java
+++ b/src/main/java/in/hangang/enums/Board.java
@@ -1,0 +1,31 @@
+package in.hangang.enums;
+
+public enum Board {
+    LECTURE_BANK("강의 자료 게시글", 1),
+    LECTURE_BANK_COMMENT("강의 자료 댓글", 2),
+    REVIEW("강의 후기 게시글", 3);
+
+    private String name;
+    private int id;
+
+    Board(String name, int id) {
+        this.name = name;
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+}

--- a/src/main/java/in/hangang/mapper/LectureMapper.java
+++ b/src/main/java/in/hangang/mapper/LectureMapper.java
@@ -11,7 +11,7 @@ import java.util.HashMap;
 @Repository
 public interface LectureMapper {
     void scrapLecture(Long userId, Long lectureId);
-    void deleteScrapLecture(Long userId, Long lectureId);
+    void deleteScrapLecture(Long userId, ArrayList<Long> lectureId);
     ArrayList<Lecture> getScrapLectureList(Long userId);
     Long checkAlreadyScraped(Long userId, Long lectureId);
     ArrayList<Lecture> getLectureList(LectureCriteria lectureCriteria);

--- a/src/main/java/in/hangang/service/LectureService.java
+++ b/src/main/java/in/hangang/service/LectureService.java
@@ -15,5 +15,5 @@ public interface LectureService {
     ArrayList<String> getSemesterDateByLectureId(Long id) throws Exception;
     void scrapLecture(Lecture lecture) throws Exception;
     ArrayList<Lecture> getScrapLectureList() throws Exception;
-    void deleteScrapLecture(Lecture lecture) throws Exception;
+    void deleteScrapLecture(ArrayList<Long> lectureId) throws Exception;
 }

--- a/src/main/java/in/hangang/service/ReportService.java
+++ b/src/main/java/in/hangang/service/ReportService.java
@@ -3,5 +3,5 @@ package in.hangang.service;
 import in.hangang.domain.Report;
 
 public interface ReportService {
-    void createReport(Integer typeId, Report report) throws Exception;
+    void createReport(Integer boardTypeId, Report report) throws Exception;
 }

--- a/src/main/java/in/hangang/service/TimetableService.java
+++ b/src/main/java/in/hangang/service/TimetableService.java
@@ -11,14 +11,14 @@ public interface TimetableService {
     ArrayList<UserTimeTable> getTableListByUserId(Long semesterDateId) throws Exception;
     void createTimetable(UserTimeTable userTimetable) throws Exception;
     void updateTimeTable(UserTimeTable userTimeTable) throws Exception;
-    void deleteTimetable(TimeTable timeTable) throws Exception;
+    void deleteTimetable(UserTimeTable userTimeTable) throws Exception;
     void createLectureOnTimeTable(TimeTable timeTable) throws Exception;
     void deleteLectureOnTimeTable(TimeTable timeTable) throws Exception;
     void createCustomLectureOnTimeTable(LectureTimeTable lectureTimeTable) throws Exception;
     void createCustomLectureOnTableByCode(CustomTimeTable customTimeTable) throws Exception;
     ArrayList<LectureTimeTable> getLectureListByTimeTableId(Long timeTableId) throws Exception;
     TimeTableMap getMainTimeTable() throws Exception;
-    void updateMainTimeTable(TimeTable timeTable) throws Exception;
+    void updateMainTimeTable(UserTimeTable userTimeTable) throws Exception;
     void createScrapLecture(LectureTimeTable lectureTimeTable) throws Exception;
     ArrayList<LectureTimeTable> getScrapLectureList() throws Exception;
     void deleteScrapLecture(LectureTimeTable lectureTimeTable) throws Exception;

--- a/src/main/java/in/hangang/serviceImpl/LectureServiceImpl.java
+++ b/src/main/java/in/hangang/serviceImpl/LectureServiceImpl.java
@@ -55,17 +55,18 @@ public class LectureServiceImpl implements LectureService {
     }
 
     @Override
-    public void deleteScrapLecture(Lecture lecture) throws Exception {
+    public void deleteScrapLecture(ArrayList<Long> lectureId) throws Exception {
         User user = userService.getLoginUser();
         //유저 정보가 없는 경우 예외 처리
         if (user==null)
             throw new RequestInputException(ErrorMessage.INVALID_USER_EXCEPTION);
         Long userId = user.getId();
+        for(int i = 0; i< lectureId.size(); i++){
+            if(lectureMapper.checkAlreadyScraped(userId, lectureId.get(i))==null)
+                throw new RequestInputException(ErrorMessage.CONTENT_NOT_EXISTS);
+        }
 
-        if(lectureMapper.checkAlreadyScraped(userId, lecture.getId())==null)
-            throw new RequestInputException(ErrorMessage.CONTENT_NOT_EXISTS);
-
-        lectureMapper.deleteScrapLecture(userId, lecture.getId());
+        lectureMapper.deleteScrapLecture(userId, lectureId);
     }
 
     @Override

--- a/src/main/java/in/hangang/serviceImpl/ReportServiceImpl.java
+++ b/src/main/java/in/hangang/serviceImpl/ReportServiceImpl.java
@@ -23,8 +23,8 @@ public class ReportServiceImpl implements ReportService {
     UserService userService;
 
     @Override
-    public void createReport(Integer typeId, Report report) throws Exception{
-        report.setType_id(typeId);
+    public void createReport(Integer boardTypeId, Report report) throws Exception{
+        report.setBoard_type_id(boardTypeId);
 
         if(report.getReport_id()==null)
             throw new RequestInputException(ErrorMessage.REQUEST_INVALID_EXCEPTION);

--- a/src/main/java/in/hangang/serviceImpl/ReviewServiceImpl.java
+++ b/src/main/java/in/hangang/serviceImpl/ReviewServiceImpl.java
@@ -14,6 +14,7 @@ import in.hangang.service.ReviewService;
 import in.hangang.service.UserService;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.annotation.Resource;
 import java.util.ArrayList;
@@ -84,6 +85,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional
     public void createReview(Review review) throws Exception {
 
         //해당 강의가 존재하는지 확인.
@@ -141,6 +143,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional
     public void likesReview(Review review) throws Exception {
         Long reviewId = review.getId();
         //id가 비어있는지 확
@@ -169,6 +172,7 @@ public class ReviewServiceImpl implements ReviewService {
 
 
     @Override
+    @Transactional
     public void scrapReview(Review review) throws Exception {
         User user = userService.getLoginUser();
         //유저 정보가 있는지 확인.
@@ -199,6 +203,7 @@ public class ReviewServiceImpl implements ReviewService {
     }
 
     @Override
+    @Transactional
     public void deleteScrapReview(Review review) throws Exception {
         User user = userService.getLoginUser();
         //유저 정보가 있는지 확인

--- a/src/main/java/in/hangang/serviceImpl/TimetableServiceImpl.java
+++ b/src/main/java/in/hangang/serviceImpl/TimetableServiceImpl.java
@@ -90,8 +90,8 @@ public class TimetableServiceImpl implements TimetableService {
     }
 
     @Override
-    public void deleteTimetable(TimeTable timeTable) throws Exception {
-        Long timeTableId = timeTable.getUser_timetable_id();
+    public void deleteTimetable(UserTimeTable userTimeTable) throws Exception {
+        Long timeTableId = userTimeTable.getId();
         //id가 비어있다면 에러
         if(timeTableId == null)
             throw new RequestInputException(ErrorMessage.VALIDATION_FAIL_EXCEPTION);
@@ -104,7 +104,7 @@ public class TimetableServiceImpl implements TimetableService {
         if(timetableMapper.getNameByTimeTableId(timeTableId)==null)
             throw new RequestInputException(ErrorMessage.CONTENT_NOT_EXISTS);
         //해당 시간표를 삭제할 권한이 있는지 확인
-       if(!timetableMapper.getUserIdByTimeTableId(timeTableId).equals(userId))
+        if(!timetableMapper.getUserIdByTimeTableId(timeTableId).equals(userId))
             throw new RequestInputException(ErrorMessage.INVALID_ACCESS_EXCEPTION);
 
         timetableMapper.deleteTimetable(timeTableId);
@@ -117,17 +117,16 @@ public class TimetableServiceImpl implements TimetableService {
             throw new RequestInputException(ErrorMessage.INVALID_USER_EXCEPTION);
         Long userId = user.getId();
         Long timeTableId = timetableMapper.getMainTimeTableId(userId);
+        TimeTableMap timeTableMap = new TimeTableMap();
+        timeTableMap = timetableMapper.getTableById(timeTableId);
+        timeTableMap.setLectureList(timetableMapper.getLectureListByTimeTableId(timeTableId));
 
-        //HashMap<ArrayList<UserTimeTable>, ArrayList<LectureTimeTable>> mainTable =
-        //        new HashMap<ArrayList<UserTimeTable>, ArrayList<LectureTimeTable>>();
-        //mainTable.put(timetableMapper.getTableById(timeTableId), getLectureListByTimeTableId(timeTableId));
-
-        return timetableMapper.getTableById(timeTableId);
+        return timeTableMap;
     }
 
-    public void updateMainTimeTable(TimeTable timeTable) throws Exception {
+    public void updateMainTimeTable(UserTimeTable userTimeTable) throws Exception {
         //id가 비어있다면 에러
-        Long timeTableId = timeTable.getUser_timetable_id();
+        Long timeTableId = userTimeTable.getId();
         if(timeTableId == null)
             throw new RequestInputException(ErrorMessage.VALIDATION_FAIL_EXCEPTION);
         User user = userService.getLoginUser();
@@ -192,6 +191,9 @@ public class TimetableServiceImpl implements TimetableService {
         //해당 테이블의 유저가 로그인 정보와 일치하는지 확인
         if(!userId.equals(timetableMapper.getUserIdByTimeTableId(timeTableId)))
             throw new RequestInputException(ErrorMessage.INVALID_ACCESS_EXCEPTION);
+
+        if(timetableMapper.isAlreadyExists(timeTableId, lectureId)==null)
+            throw new RequestInputException(ErrorMessage.CONTENT_NOT_EXISTS);
 
         //삭제 방식에 대한 고민
         timetableMapper.deleteLectureOnTimeTable(timeTableId, lectureId);

--- a/src/main/java/in/hangang/util/Scheduler.java
+++ b/src/main/java/in/hangang/util/Scheduler.java
@@ -48,9 +48,11 @@ public class Scheduler {
         hashTagService.updateTop3HashTag();
     }
 
-    @Scheduled(cron = "0 0 0 */1 * *")
-    public void updateReviewCount() {lectureService.updateReviewCount();}
 
-    @Scheduled(cron = "0 0 0 ? * 6")
-    public void cleanUnavailableFiles() throws Exception {lectureBankService.hardDeleteFile();}
+    //@Scheduled(cron = "0 0 0 1 * *")
+    //public void updateReviewCount() {lectureService.updateReviewCount();}
+
+    // 에러나서 주석처리했습니다.
+    //@Scheduled(cron = "0 0 0 ? * 6")
+    //public void cleanUnavailableFiles() throws Exception {lectureBankService.hardDeleteFile();}
 }

--- a/src/main/resources/mapper/LectureMapper.xml
+++ b/src/main/resources/mapper/LectureMapper.xml
@@ -13,7 +13,10 @@
         INSERT INTO hangang.scraps(user_id, lecture_id) VALUES(#{userId}, #{lectureId});
     </insert>
     <update id="deleteScrapLecture">
-        UPDATE hangang.scraps SET is_deleted = 1 WHERE user_id = #{userId} AND lecture_id = #{lectureId};
+        UPDATE hangang.scraps SET is_deleted = 1 WHERE user_id = #{userId} AND
+        <foreach collection="lectureId" item="lectureId" open="(" close=")" separator="or">
+            lecture_id = #{lectureId}
+        </foreach>
     </update>
 
     <select id="checkAlreadyScraped" resultType="Long">
@@ -131,11 +134,6 @@
         <collection property="top3_hash_tag" javaType="java.util.ArrayList" column="id"
                     ofType="in.hangang.domain.HashTag" select="in.hangang.mapper.HashTagMapper.getTop3HashTag">
         </collection>
-        <!--
-        <collection property="total_rating" javaType="String" column="id"
-                    select="in.hangang.mapper.TotalEvaluationMapper.getTotalRating">
-        </collection>
-        -->
     </resultMap>
 
     <select id="checkLectureExists" resultType="Long">

--- a/src/main/resources/mapper/ReportMapper.xml
+++ b/src/main/resources/mapper/ReportMapper.xml
@@ -2,10 +2,10 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="in.hangang.mapper.ReportMapper">
     <insert id="createReport">
-        INSERT INTO hangang.report_log(type_id, content_id, report_id, user_id) VALUES(#{type_id}, #{content_id}, #{report_id}, #{user_id});
+        INSERT INTO hangang.report_log(board_type_id, content_id, report_id, user_id) VALUES(#{board_type_id}, #{content_id}, #{report_id}, #{user_id});
     </insert>
 
     <select id="checkAlreadyReported" resultType="Long">
-        SELECT id FROM hangang.report_log WHERE type_id = #{type_id} AND content_id = #{content_id} AND user_id = #{user_id};
+        SELECT id FROM hangang.report_log WHERE board_type_id = #{board_type_id} AND content_id = #{content_id} AND user_id = #{user_id};
     </select>
 </mapper>

--- a/src/main/resources/mapper/TimetableMapper.xml
+++ b/src/main/resources/mapper/TimetableMapper.xml
@@ -55,8 +55,10 @@
         <result column="id" property="id"/>
         <result column="semester_date_id" property="tableSemesterDate"/>
         <result column="name" property="tableName"/>
+        <!--
         <collection property="lectureList" ofType="in.hangang.domain.LectureTimeTable" column="{id=id}" select="getLectureListByTimeTableId">
         </collection>
+        -->
     </resultMap>
 
     <select id="getClassTimeByLectureId" resultType="String">
@@ -207,6 +209,9 @@
         <result column="class_time" property="class_time"/>
         <result column="created_at" property="created_at"/>
         <result column="updated_at" property="updated_at"/>
+        <collection
+                property="rating" column="{name=name, professor=professor}" select="getRatingByNameAndProfessor">
+        </collection>
     </resultMap>
 
     <resultMap id="lectureList" type="in.hangang.domain.LectureTimeTable">


### PR DESCRIPTION
변경사항
- 시간표 삭제 기능 (DELETE /timetable)
    - 기존 “user_timetable_id” 가 아닌 “id”로 삭제 요청하도록 수정했습니다. (파라미터 이름 변경)
- 메인 시간표 변경 기능 (PATCH /timetable/main/lecture)
    - 위와 동일하게 기존 “user_timetable_id” 에서 “id”로 파라미터 이름 변경
- 메인 시간표 보기 (GET /timetable/main/lecture)
    - 기존 강의만 반환하는 방식에서 시간표 정보(학기, 시간표 이름)를 함께 반환하도록 변경되었습니다.
- 신고 기능 관련 DB, enum 변경


에러 발생 확인 
- 시간표에 강의를 추가할 때 강의 시간이 비어있는 강의인 경우 에러 발생 (NumberFormatException)

버그 픽스
- 시간표안에 있지 않은 강의를 삭제 요청해도 에러가 발생하지 않는 문제 해결
