### PR TITLE
Fix : GlobalExceptionHandler 수정 (ClientAbortException 무시)

### DIFF
--- a/src/main/java/in/hangang/config/GlobalExceptionHandler.java
+++ b/src/main/java/in/hangang/config/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import in.hangang.exception.CriticalException;
 import in.hangang.exception.NonCriticalException;
 import in.hangang.exception.TimeTableException;
 import in.hangang.util.Parser;
+import org.apache.catalina.connector.ClientAbortException;
 import org.springframework.beans.factory.annotation.Value;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -93,6 +94,9 @@ public class GlobalExceptionHandler {
 			baseException.setErrorTrace(e.getStackTrace()[0].toString());
 			slack = true;
 		}
+
+		if (e instanceof ClientAbortException)
+			slack = false;
 
 		if(slack.equals(true)){
 			sendSlackNoti(e,handlerMethod);


### PR DESCRIPTION
# 개요
> ClientAbortException 발생
>> Message : java.io.IOException: Broken pipe
>> Controller : springfox.documentation.swagger2.web.Swagger2Controller#getDocumentation(String, HttpServletRequest)

# 발생 이유
* ClientAbortException은 Hangang 애플리케이션에서 발생하는 것이 아닌, Tomcat 컨테이너에서 특정 상황에 발생
* 해당 예외는 클라이언트에서 서버로 요청을 한 뒤 응답을 받기전에 요청이 중단 되었을 경우 발생 가능함

# 해결 방안
> 에러 핸들러인 GlobalExceptionHandler에서 ClientAbortException을 무시하는 로직 추가
>> ClientAbortException에 대해서는 slack 노티를 보내지 않도록 처리
